### PR TITLE
Fixes LIMIT rewrite for paginated, nested subqueries

### DIFF
--- a/Platforms/DblibPlatform.php
+++ b/Platforms/DblibPlatform.php
@@ -105,7 +105,7 @@ class DblibPlatform extends SQLServer2008Platform
                 //$query = "SELECT * FROM (SELECT ROW_NUMBER() OVER ($over) AS \"doctrine_rownum\", $query) AS doctrine_tbl WHERE doctrine_rownum BETWEEN $start AND $end";
                 
                 // distinct x must be first in the select list - didn't work with above
-                list($select_list, $from_part) = explode('FROM', $query);
+                list($select_list, $from_part) = explode('FROM', $query, 2);
                 $query = "SELECT * FROM (SELECT $select_list, ROW_NUMBER() OVER ($over) AS \"doctrine_rownum\" FROM $from_part) AS doctrine_tbl WHERE doctrine_rownum BETWEEN $start AND $end";
                 
             }


### PR DESCRIPTION
When subqueries are present, the "explode" will split the query on every `FROM`, and everything after the first one will be discarded when the rewritten query is reassembled. Adding the `limit` parameter to the `explode()` call ensures that subqueries are not truncated.